### PR TITLE
build with default prefix, adjust all octave dirs

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -52,12 +52,12 @@ layout:
 
 apps:
   octave:
-    command: usr/bin/octave
-    desktop: usr/share/applications/org.octave.Octave.desktop
+    command: bin/octave
+    desktop: share/applications/org.octave.Octave.desktop
     common-id: org.octave.Octave
     environment:
-      OCTAVE_HOME: "$SNAP/usr"
-      LD_LIBRARY_PATH: "$SNAP/usr/lib/octave/$SNAPCRAFT_PROJECT_VERSION"
+      OCTAVE_HOME: "$SNAP"
+      LD_LIBRARY_PATH: "$SNAP/lib/octave/$SNAPCRAFT_PROJECT_VERSION"
       LOCPATH: "$SNAP/usr/lib/locale"
     plugs:
       - desktop
@@ -70,10 +70,10 @@ apps:
       - wayland
       - x11
   octave-cli:
-    command: usr/bin/octave-cli
+    command: bin/octave-cli
     environment:
-      OCTAVE_HOME: "$SNAP/usr"
-      LD_LIBRARY_PATH: "$SNAP/usr/lib/octave/$SNAPCRAFT_PROJECT_VERSION"
+      OCTAVE_HOME: "$SNAP"
+      LD_LIBRARY_PATH: "$SNAP/lib/octave/$SNAPCRAFT_PROJECT_VERSION"
       LOCPATH: "$SNAP/usr/lib/locale"
     plugs:
       - desktop
@@ -118,12 +118,10 @@ parts:
     source-type: tar
     source: https://ftpmirror.gnu.org/octave/octave-5.1.0.tar.xz
     source-checksum: sha256/87b4df6dfa28b1f8028f69659f7a1cabd50adfb81e1e02212ff22c863a29454e
-    configflags:
-      - --prefix=/usr
     after: [alsa]
     override-prime: |
       snapcraftctl prime
-      sed -i 's|^Icon=octave|Icon=/usr/share/icons/hicolor/scalable/apps/octave.svg|' usr/share/applications/org.octave.Octave.desktop
+      sed -i 's|^Icon=octave|Icon=/share/icons/hicolor/scalable/apps/octave.svg|' share/applications/org.octave.Octave.desktop
     build-packages:
       - gfortran
       - libarpack2-dev


### PR DESCRIPTION
Build without '--prefix=/usr', install according to snapcraft defaults.
Adjust OCTAVE_HOME and all octave directories accordingly.