### PR TITLE
add build flags, strip debug info, sanitize flags for mkoctfile

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -127,6 +127,13 @@ parts:
       - INSTALL_PROGRAM: "/usr/bin/install -s"
       - INSTALL_STRIP_FLAG: "-s"
       - LDFLAGS: "-Wl,-z,relro $LDFLAGS"
+    override-build: |
+      sed -i "s|%OCTAVE_CONF_CFLAGS%|\"-g -O2 -fstack-protector-strong\"|" src/mkoctfile.in.cc
+      sed -i "s|%OCTAVE_CONF_CPPFLAGS%|\"-D_FORTIFY_SOURCE=2\"|" src/mkoctfile.in.cc
+      sed -i "s|%OCTAVE_CONF_CXXFLAGS%|\"-g -O2 -fstack-protector-strong\"|" src/mkoctfile.in.cc
+      sed -i "s|%OCTAVE_CONF_LDFLAGS%|\"-Wl,-z,relro\"|" src/mkoctfile.in.cc
+      sed -i "s|%OCTAVE_CONF_OCT_LINK_OPTS%|\"-Wl,-z,relro\"|" src/mkoctfile.in.cc
+      snapcraftctl build
     after: [alsa]
     override-prime: |
       snapcraftctl prime

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -118,6 +118,15 @@ parts:
     source-type: tar
     source: https://ftpmirror.gnu.org/octave/octave-5.1.0.tar.xz
     source-checksum: sha256/87b4df6dfa28b1f8028f69659f7a1cabd50adfb81e1e02212ff22c863a29454e
+    build-environment:
+      - CFLAGS: "-g -O2 -fstack-protector-strong $CFLAGS"
+      - CPPFLAGS: "-D_FORTIFY_SOURCE=2 $CPPFLAGS"
+      - CXXFLAGS: "-g -O2 -fstack-protector-strong $CXXFLAGS"
+      - FFLAGS: "-g -O2 $FFLAGS"
+      - FLIBS: "-lgfortran -lquadmath -lm"
+      - INSTALL_PROGRAM: "/usr/bin/install -s"
+      - INSTALL_STRIP_FLAG: "-s"
+      - LDFLAGS: "-Wl,-z,relro $LDFLAGS"
     after: [alsa]
     override-prime: |
       snapcraftctl prime


### PR DESCRIPTION
Build Octave with a sane set of standard build flags. Strip all debug info from binaries and shared objects when installling / staging. Sanitize the build flags stored in mkoctfile, since snap appends some -I and -L options of its own.