### PR TITLE
feat: install mpmath and sympy from PyPI

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -194,6 +194,14 @@ parts:
       - pkg-config
       - texinfo
 
+  python-packages:
+    plugin: python
+    python-packages:
+      - mpmath==1.1.0
+      - sympy==1.5.1
+    prime:
+      - -bin/isympy
+
 layout:
   /usr/lib/$SNAPCRAFT_ARCH_TRIPLET/alsa-lib:
     bind: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/alsa-lib


### PR DESCRIPTION
Ensure that SymPy is available for the symbolic package. As a side
effect, additional packages can be pip installed in the user directory.
Fixes #32, fixes #33.