### PR TITLE
feat: include python3-venv in stage-packages

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -193,6 +193,7 @@ parts:
       - libumfpack5
       - locales-all
       - pkg-config
+      - python3-venv
       - texinfo
 
   python-packages:


### PR DESCRIPTION
Include python3-venv in the snap so that users can create virtual
environments. Fixes #43.