### PR TITLE
fix: add layout for python-wheels directory

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -252,3 +252,7 @@ layout:
     symlink: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libmvec_nonshared.a
   /usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libpthread_nonshared.a:
     symlink: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libpthread_nonshared.a
+
+  # Make staged Python wheels available in expected system directory
+  /usr/share/python-wheels:
+    symlink: $SNAP/usr/share/python-wheels


### PR DESCRIPTION
The fixed path for Python wheels is hard-coded into the ensurepip
module, add a layout for that expected location. Fixes #43, really.