### PR TITLE
fix: build with snapcraft 5.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ jobs:
       - name: Build snap
         id: snapcraft
         uses: snapcore/action-build@v1
+        with:
+          snapcraft-channel: 5.x/stable
 
       - name: Archive snap artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -12,8 +12,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Lint code base
-        uses: github/super-linter@v4
+        uses: github/super-linter/slim@v4
         env:
           DEFAULT_BRANCH: develop
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_GITHUB_ACTIONS: false
           VALIDATE_JSCPD: false

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Lint code base
-        uses: github/super-linter@v3
+        uses: github/super-linter@v4
         env:
           DEFAULT_BRANCH: develop
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,6 +16,8 @@ jobs:
       - name: Build snap
         id: snapcraft
         uses: snapcore/action-build@v1
+        with:
+          snapcraft-channel: 5.x/stable
 
       - name: Archive snap artifact
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Work around autotools build regression in snapcraft 6.x for now.
Fixes #97.